### PR TITLE
fix: resolve capture and apply issues (#28, #29, #30, #31, #32)

### DIFF
--- a/internal/app/capture_to_config.go
+++ b/internal/app/capture_to_config.go
@@ -1110,7 +1110,7 @@ func parseSSHConfig(configPath string) ([]captureSSHHostYAML, *captureSSHDefault
 
 			inGlobalSection = false
 			currentHost = &captureSSHHostYAML{
-				Name: value,
+				Host: value,
 			}
 			continue
 		}
@@ -1434,7 +1434,7 @@ type captureSSHDefaults struct {
 }
 
 type captureSSHHostYAML struct {
-	Name         string `yaml:"name"`                    // Host alias
+	Host         string `yaml:"host"`                    // Host alias (matches SSHHostConfig.Host)
 	HostName     string `yaml:"hostname,omitempty"`      // Actual hostname (may be redacted)
 	User         string `yaml:"user,omitempty"`          // Username
 	IdentityFile string `yaml:"identity_file,omitempty"` // Path to key file

--- a/internal/app/capture_to_config_test.go
+++ b/internal/app/capture_to_config_test.go
@@ -723,8 +723,8 @@ Host work
 		// Verify SSH config structure
 		assert.Contains(t, string(content), "ssh:")
 		assert.Contains(t, string(content), "hosts:")
-		assert.Contains(t, string(content), "name: github.com")
-		assert.Contains(t, string(content), "name: work")
+		assert.Contains(t, string(content), "host: github.com")
+		assert.Contains(t, string(content), "host: work")
 		assert.Contains(t, string(content), "hostname: work.example.com")
 		assert.Contains(t, string(content), "port: \"2222\"")
 	})

--- a/internal/app/dotfiles_capture.go
+++ b/internal/app/dotfiles_capture.go
@@ -139,6 +139,11 @@ func DefaultCaptureConfigs() []DotfilesCaptureConfig {
 		{
 			Provider: "shell",
 			SourcePaths: []string{
+				"~/.zshrc",
+				"~/.zshenv",
+				"~/.zprofile",
+				"~/.zlogin",
+				"~/.zlogout",
 				"~/.zshrc.d",
 				"~/.config/zsh",
 				"~/.zsh",
@@ -204,6 +209,32 @@ func DefaultCaptureConfigs() []DotfilesCaptureConfig {
 				"credentials",
 			},
 			TargetDir: "git",
+		},
+		{
+			Provider: "terminal",
+			SourcePaths: []string{
+				// WezTerm
+				"~/.wezterm.lua",
+				"~/.config/wezterm",
+				// Alacritty
+				"~/.alacritty.toml",
+				"~/.alacritty.yml",
+				"~/.config/alacritty",
+				// Kitty
+				"~/.config/kitty",
+				// Hyper
+				"~/.hyper.js",
+				"~/.config/hyper",
+				// iTerm2 (macOS)
+				"~/Library/Preferences/com.googlecode.iterm2.plist",
+				// Ghostty
+				"~/.config/ghostty",
+			},
+			ExcludePaths: []string{
+				"*.log",
+				"cache",
+			},
+			TargetDir: "terminal",
 		},
 	}
 }

--- a/internal/app/operations_test.go
+++ b/internal/app/operations_test.go
@@ -977,3 +977,68 @@ func TestDoctorOptions_WithUpdateConfig(t *testing.T) {
 	assert.True(t, opts.UpdateConfig)
 	assert.True(t, opts.DryRun)
 }
+
+func TestIsValidGoModulePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "valid github.com path",
+			path:     "github.com/user/tool",
+			expected: true,
+		},
+		{
+			name:     "valid golang.org path",
+			path:     "golang.org/x/tools/cmd/goimports",
+			expected: true,
+		},
+		{
+			name:     "valid gitlab.com path",
+			path:     "gitlab.com/group/project/cmd/cli",
+			expected: true,
+		},
+		{
+			name:     "simple name without domain",
+			path:     "relicta",
+			expected: false,
+		},
+		{
+			name:     "name with slash but no domain",
+			path:     "user/tool",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			path:     "",
+			expected: false,
+		},
+		{
+			name:     "starts with dot",
+			path:     "./local/path",
+			expected: false,
+		},
+		{
+			name:     "starts with slash",
+			path:     "/absolute/path",
+			expected: false,
+		},
+		{
+			name:     "domain only without path",
+			path:     "github.com",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := isValidGoModulePath(tc.path)
+			assert.Equal(t, tc.expected, result, "path: %s", tc.path)
+		})
+	}
+}

--- a/internal/provider/nvim/provider.go
+++ b/internal/provider/nvim/provider.go
@@ -52,8 +52,8 @@ func (p *Provider) Compile(ctx compiler.CompileContext) ([]compiler.Step, error)
 	case cfg.ConfigRepo != "":
 		// Add config repo step if specified (alternative to preset)
 		steps = append(steps, NewConfigRepoStep(cfg.ConfigRepo, p.fs, p.runner))
-	case cfg.Preset != "":
-		// Add preset step if specified
+	case cfg.Preset != "" && cfg.Preset != "custom":
+		// Add preset step if specified (skip "custom" which means user has their own config)
 		steps = append(steps, NewPresetStep(cfg.Preset, p.fs, p.runner))
 	}
 

--- a/internal/provider/nvim/provider_test.go
+++ b/internal/provider/nvim/provider_test.go
@@ -94,3 +94,23 @@ func TestProvider_Compile_PresetWithLazyLock(t *testing.T) {
 	// preset step + lazy-lock step
 	assert.Len(t, steps, 2)
 }
+
+func TestProvider_Compile_CustomPreset_NoSteps(t *testing.T) {
+	t.Parallel()
+
+	fs := mocks.NewFileSystem()
+	runner := mocks.NewCommandRunner()
+	p := nvim.NewProvider(fs, runner)
+
+	// "custom" preset means user has their own config - no step should be created
+	raw := map[string]interface{}{
+		"nvim": map[string]interface{}{
+			"preset": "custom",
+		},
+	}
+	ctx := compiler.NewCompileContext(raw)
+	steps, err := p.Compile(ctx)
+
+	require.NoError(t, err)
+	assert.Empty(t, steps, "custom preset should not create any steps")
+}


### PR DESCRIPTION
## Summary

Fixes 5 bugs affecting dotfiles capture and configuration apply:

- **#28**: nvim preset 'custom' not recognized during apply
- **#29**: go:tool capture creates invalid module path  
- **#30**: SSH config corrupts Host directive (loses argument)
- **#31**: capture misses ~/.zshrc
- **#32**: capture misses terminal emulator configs

## Changes

### #28: nvim preset 'custom' fix
Skip creating PresetStep when preset is "custom" since user has own config. Added test `TestProvider_Compile_CustomPreset_NoSteps`.

### #29: go:tool module path validation
- Extract actual Go module paths using `go version -m` binary inspection
- Add `isValidGoModulePath()` to validate paths contain domain and slash
- Filter out tools without valid module paths (e.g., standalone binaries)

### #30: SSH config Host directive fix
Fix field name mismatch: capture used `name` YAML key, apply expects `host`. Changed `captureSSHHostYAML.Name` to `captureSSHHostYAML.Host` with `yaml:"host"` tag.

### #31: zshrc capture
Added `~/.zshrc`, `~/.zshenv`, `~/.zprofile`, `~/.zlogin`, `~/.zlogout` to shell capture paths.

### #32: terminal emulator configs
Added new "terminal" provider with support for:
- WezTerm (~/.wezterm.lua, ~/.config/wezterm)
- Alacritty (~/.alacritty.toml, ~/.alacritty.yml, ~/.config/alacritty)
- Kitty (~/.config/kitty)
- Hyper (~/.hyper.js, ~/.config/hyper)
- iTerm2 (~/Library/Preferences/com.googlecode.iterm2.plist)
- Ghostty (~/.config/ghostty)

## Test plan

- [x] All existing tests pass
- [x] Added test for nvim custom preset
- [x] Added test for Go module path validation
- [x] Updated SSH test assertions for new field name

Closes #28, #29, #30, #31, #32