### PR TITLE
feat(mcp): advertise output schemas for data tools

### DIFF
--- a/internal/mcp/output_schema_test.go
+++ b/internal/mcp/output_schema_test.go
@@ -1,0 +1,45 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.klarlabs.de/mcp/schema"
+)
+
+// TestOutputSchemaGenerates guards the output schemas advertised by the
+// data-returning tools. OutputSchema runs schema.Generate at registration
+// time; if generation errors, the ToolBuilder captures the error and the
+// tool is silently dropped from the server. This test fails loudly instead,
+// so a future change to any advertised output type that breaks schema
+// generation is caught immediately.
+func TestOutputSchemaGenerates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		example any
+	}{
+		{"PlanOutput", PlanOutput{}},
+		{"DoctorOutput", DoctorOutput{}},
+		{"ValidateOutput", ValidateOutput{}},
+		{"StatusOutput", StatusOutput{}},
+		{"DiffOutput", DiffOutput{}},
+		{"TourOutput", TourOutput{}},
+		{"SecurityOutput", SecurityOutput{}},
+		{"OutdatedOutput", OutdatedOutput{}},
+		{"MarketplaceOutput", MarketplaceOutput{}},
+		{"ToolAnalyzeOutput", ToolAnalyzeOutput{}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s, err := schema.Generate(tt.example)
+			require.NoError(t, err, "schema.Generate must not error for advertised output type %s", tt.name)
+			require.NotNil(t, s, "schema.Generate must return a schema for %s", tt.name)
+		})
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -436,6 +436,7 @@ func registerPlanTool(srv *mcp.Server, preflight *app.Preflight, defaultConfig, 
 	srv.Tool("preflight_plan").
 		Description("Show what changes preflight would make to your system. Creates an execution plan without making changes.").
 		ReadOnly().
+		OutputSchema(PlanOutput{}).
 		Handler(func(ctx context.Context, in PlanInput) (*PlanOutput, error) {
 			// Validate inputs
 			if err := ValidatePlanInput(&in); err != nil {
@@ -568,6 +569,7 @@ func registerDoctorTool(srv *mcp.Server, preflight *app.Preflight, defaultConfig
 	srv.Tool("preflight_doctor").
 		Description("Verify system state against configuration and detect drift. Reports issues and suggests fixes.").
 		ReadOnly().
+		OutputSchema(DoctorOutput{}).
 		Handler(func(ctx context.Context, in DoctorInput) (*DoctorOutput, error) {
 			// Validate inputs
 			if err := ValidateDoctorInput(&in); err != nil {
@@ -628,6 +630,7 @@ func registerValidateTool(srv *mcp.Server, preflight *app.Preflight, defaultConf
 	srv.Tool("preflight_validate").
 		Description("Validate configuration without applying. Useful for CI/CD pipelines.").
 		ReadOnly().
+		OutputSchema(ValidateOutput{}).
 		Handler(func(ctx context.Context, in ValidateInput) (*ValidateOutput, error) {
 			// Validate inputs
 			if err := ValidateValidateInput(&in); err != nil {
@@ -676,6 +679,7 @@ func registerStatusTool(srv *mcp.Server, preflight *app.Preflight, defaultConfig
 	srv.Tool("preflight_status").
 		Description("Get current preflight status including version info, config validity, and drift detection.").
 		ReadOnly().
+		OutputSchema(StatusOutput{}).
 		Handler(func(ctx context.Context, in StatusInput) (*StatusOutput, error) {
 			// Validate inputs
 			if err := ValidateStatusInput(&in); err != nil {
@@ -789,6 +793,7 @@ func registerDiffTool(srv *mcp.Server, preflight *app.Preflight, defaultConfig, 
 	srv.Tool("preflight_diff").
 		Description("Show differences between configuration and current system state.").
 		ReadOnly().
+		OutputSchema(DiffOutput{}).
 		Handler(func(ctx context.Context, in DiffInput) (*DiffOutput, error) {
 			// Validate inputs
 			if err := ValidateDiffInput(&in); err != nil {
@@ -832,6 +837,7 @@ func registerTourTool(srv *mcp.Server) {
 	srv.Tool("preflight_tour").
 		Description("List available interactive tour topics. Tours provide guided walkthroughs of preflight features.").
 		ReadOnly().
+		OutputSchema(TourOutput{}).
 		Handler(func(_ context.Context, _ TourInput) (*TourOutput, error) {
 			topics := tui.GetAllTopics()
 
@@ -857,6 +863,7 @@ func registerSecurityTool(srv *mcp.Server) {
 	srv.Tool("preflight_security").
 		Description("Scan for security vulnerabilities using Grype or Trivy. Reports CVEs with severity levels.").
 		ReadOnly().
+		OutputSchema(SecurityOutput{}).
 		Handler(func(ctx context.Context, in SecurityInput) (*SecurityOutput, error) {
 			registry := security.NewScannerRegistry()
 			registry.Register(security.NewGrypeScanner())
@@ -962,6 +969,7 @@ func registerOutdatedTool(srv *mcp.Server) {
 	srv.Tool("preflight_outdated").
 		Description("Check for outdated packages. Reports available updates with version information.").
 		ReadOnly().
+		OutputSchema(OutdatedOutput{}).
 		Handler(func(ctx context.Context, in OutdatedInput) (*OutdatedOutput, error) {
 			registry := security.NewOutdatedCheckerRegistry()
 			checker := security.NewBrewOutdatedChecker()
@@ -1232,6 +1240,7 @@ func registerMarketplaceTool(srv *mcp.Server) {
 	srv.Tool("preflight_marketplace").
 		Description("Browse and search the marketplace for presets, capability packs, and layer templates.").
 		ReadOnly().
+		OutputSchema(MarketplaceOutput{}).
 		Handler(func(ctx context.Context, in MarketplaceInput) (*MarketplaceOutput, error) {
 			svc := marketplace.NewService(marketplace.DefaultServiceConfig())
 
@@ -1322,6 +1331,7 @@ func registerToolAnalyzeTool(srv *mcp.Server) {
 	srv.Tool("preflight_analyze_tools").
 		Description("Analyze development tools for redundancy, deprecation warnings, and consolidation opportunities. Detects deprecated tools (golint → golangci-lint), redundant tools (grype + trivy → keep trivy), and consolidation opportunities ([grype, syft, gitleaks] → trivy).").
 		ReadOnly().
+		OutputSchema(ToolAnalyzeOutput{}).
 		Handler(func(ctx context.Context, in ToolAnalyzeInput) (*ToolAnalyzeOutput, error) {
 			// Validate inputs
 			if err := ValidateToolAnalyzeInput(&in); err != nil {


### PR DESCRIPTION
## Summary

Adopts mcp-go's structured-output support (`OutputSchema` + `structuredContent`) for the read/query/analysis MCP tools that return genuine structured-data objects. Adding `.OutputSchema(T{})` before `.Handler(...)` makes the server advertise an `outputSchema` in `tools/list` and emit typed `structuredContent` alongside the existing JSON text, so MCP clients receive machine-readable, schema-described results.

All adopted handlers already returned typed struct pointers, so no handler refactoring was required — this is a purely additive, one-line-per-tool change plus a guard test.

## Adopted (10 read-only tools)

Each already returns a typed struct whose top level is a JSON object:

- `preflight_plan` → `PlanOutput`
- `preflight_doctor` → `DoctorOutput`
- `preflight_validate` → `ValidateOutput`
- `preflight_status` → `StatusOutput`
- `preflight_diff` → `DiffOutput`
- `preflight_tour` → `TourOutput`
- `preflight_security` → `SecurityOutput`
- `preflight_outdated` → `OutdatedOutput`
- `preflight_marketplace` → `MarketplaceOutput`
- `preflight_analyze_tools` → `ToolAnalyzeOutput`

## Skipped (with reasons)

- `preflight_apply` — destructive mutation
- `preflight_sync` — destructive mutation
- `preflight_capture` — mutation (machine capture)
- `preflight_rollback` — mutation (snapshot restore)

## Guard test

`OutputSchema` runs `schema.Generate` at registration time; if generation errors, the `ToolBuilder` captures the error and the tool is **silently dropped** from the server. `TestOutputSchemaGenerates` asserts `schema.Generate` succeeds for every advertised output type, so a future type change that breaks schema generation fails loudly in CI instead of quietly removing a tool.

## Verification

- `gofmt -l` on changed files: clean
- `go build ./...`: passes
- `go vet ./...`: passes
- `go test ./...`: `internal/mcp` passes (incl. new guard test). One unrelated failure in `cmd/preflight` `TestFindRepoRoot` is a git-worktree artifact (asserts `.git` is a directory; in a worktree `.git` is a gitdir-pointer file) — not caused by this change.
- `golangci-lint run ./internal/mcp/`: 0 issues

https://claude.ai/code/session_01LCyhyAffdzBmzG3yPPqzTT